### PR TITLE
:children_crossing: Add the ability to query by day by more shorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Returns a list of all allergens.
 
 | Name    | Type   | Description                                                                                                                               |
 | ------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `day`   | string | The day of the week. Valid values are `mo`, `di`, `mi`, `do`, `fr`, `sa` and `so`.                                                                    |
+| `day`   | string | The day of the week. Valid values are `mo`, `tu`, `we`, `th`, `fr`, `sa` and `so`.                                                                    |
 | `week`  | string | The week. Valid values are `current` for the current week and `next` for the next                                                         |
 | `mensa` | string | Location. Valid values are `mh` for the cafeteria in the 'Musikhochschule'. everything else defaults back to 'Mensa Lübeck mit Cafeteria' |
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Returns a list of all allergens.
 
 | Name    | Type   | Description                                                                                                                               |
 | ------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `day`   | string | The day of the week. Valid values are `mo`, `tu`, `we`, `th`, `fr`, `sa` and `so`.                                                                    |
+| `day`   | string | The day of the week. Valid values are `mon`, `tue`, `wed`, `thu`, `fri`, `sat` and `sun`.                                                                    |
 | `week`  | string | The week. Valid values are `current` for the current week and `next` for the next                                                         |
 | `mensa` | string | Location. Valid values are `mh` for the cafeteria in the 'Musikhochschule'. everything else defaults back to 'Mensa Lübeck mit Cafeteria' |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ app.use(cors());
 
 const PORT = process.env.PORT || 3000;
 
-const weekdays = ["so", "mo", "di", "mi", "do", "fr", "sa"];
+const weekdays = [
+    ["so", "mo", "di", "mi", "do", "fr", "sa"],
+    ["su", "mo", "tu", "we", "th", "fr", "sa"],
+    ["sun", "mon", "tue", "wed", "thu", "fri", "sat"],
+    ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
+]
 
 app.get('/', (req: Request, res: Response) => {
     res.json({
@@ -26,7 +31,7 @@ app.get('/meals', async (req: Request, res: Response, next: NextFunction) => {
         data = data.speiseplan
 
         if (params.day) {
-            data = data.filter(day => new Date(day.date).getDay() === weekdays.indexOf(params.day?.toString().toLowerCase() ?? ""));
+            data = data.filter(day => new Date(day.date).getDay() === weekdays.find(weekday => weekday.includes(params.day?.toString().toLowerCase() ?? ""))?.indexOf(params.day?.toString().toLowerCase() ?? ""));
         }
         if (params.week) {
             data = data.filter(day => day.week === params.week?.toString());


### PR DESCRIPTION
It is now possible to query the day by two character code in German and English, by three character code and full weekday-name in English.